### PR TITLE
Fix obstructed year on journal dashboard

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -96,8 +96,16 @@ def articleDashboard():
 
 @ app.route('/journalDashboard', methods=["GET", "POST"])
 def journalDashboard():
+
+    # Get the current year so we can pass it to the graph X axis
+    # The earliest year we consider is 1997
+    years_list = []
+    currentYear = datetime.now().year
+    for i in range(1997, currentYear + 1):
+        years_list.append(i)
+
     # Go to journalDashboardLogic.py
-    return journalDashboardLogic(mysql)
+    return journalDashboardLogic(mysql, years_list)
 
 
 @ app.route('/authorDashboard', methods=["GET", "POST"])

--- a/web/authorDashboardLogic.py
+++ b/web/authorDashboardLogic.py
@@ -258,7 +258,8 @@ def authorDashboardLogic(mysql, mysql2, years_list, yearInput):
 
     return flask.render_template('authorDashboard.html',
                                  author_name=author_name['name'],
-                                 years_list=years_list, yearInput=yearInput,
+                                 years_list=years_list, 
+                                 yearInput=yearInput,
                                  passed_author_id=author_id,  # this is for the year filter!
                                  author_article_list=author_article_list,
                                  cambiaEventData=cambiaEvent,

--- a/web/journalDashboardLogic.py
+++ b/web/journalDashboardLogic.py
@@ -2,7 +2,7 @@ import flask
 from flask_paginate import Pagination, get_page_parameter, get_per_page_parameter
 
 
-def journalDashboardLogic(mysql):
+def journalDashboardLogic(mysql, years_list):
 
     journal_list = []  # list initializing
     cursor = mysql.connection.cursor()
@@ -91,5 +91,8 @@ def journalDashboardLogic(mysql):
                                  pagination=pagination,
                                  article_start=article_start,
                                  article_end=article_end,
-                                 perPage=perPage, start_year=copyStartYear, end_year=end_year
+                                 perPage=perPage, 
+                                 start_year=copyStartYear, 
+                                 end_year=end_year,
+                                 years_list=years_list,
                                  )

--- a/web/static/js/journalChart.js
+++ b/web/static/js/journalChart.js
@@ -1,6 +1,5 @@
-// These should not change - for now. Need to set dynamically in the future
-const xAxis = [1995,1996,1997,1998,1999,2000,2001,2002,2003,2004,2005,2006,2007,2008,2009,2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020]
-
+// With Jinja templates, this is the best way to get the year list from Python -> JavaScript.
+const xAxis = years_list
 // 'x' needs to be in the [0] position, because it is the title of our array, and C3 demands the title be at [0].
 xAxis.unshift('x');
 

--- a/web/templates/journalDashboard.html
+++ b/web/templates/journalDashboard.html
@@ -147,6 +147,16 @@
 </script>
 {% endfor %}
 
+<script>
+    years_list = [];
+</script>
+
+{% for year in years_list %}
+<script>
+    years_list.push("{{ year }}")
+</script>
+{% endfor %}
+
 <!-- Load JS for chart -->
 <script src="../static/js/journalChart.js"></script>
 {% endblock %}


### PR DESCRIPTION
I also improved the journalScript chart. It now receives a list of years from Python rather than simply 1997-2020. This means it will work in 2021 and beyond.

Closes #423 