### PR TITLE
Improve Ubuntu compatibility +  Improve spacing between chart and form

### DIFF
--- a/SQL/CrossrefeventdataWithMain/crossrefeventdataWithMain.sql
+++ b/SQL/CrossrefeventdataWithMain/crossrefeventdataWithMain.sql
@@ -1,7 +1,7 @@
-CREATE DATABASE crossRefEventDataMain;
-USE crossRefEventDataMain;
+CREATE DATABASE crossrefeventdatamain;
+USE crossrefeventdatamain;
 
-CREATE TABLE IF NOT EXISTS Main
+CREATE TABLE IF NOT EXISTS main
 (
 	-- To uniquely identify each row. Autoincrements for an easy primary key.
 	increment				BIGINT AUTO_INCREMENT,
@@ -143,7 +143,7 @@ CREATE TABLE IF NOT EXISTS Main
 
 
 
-CREATE TABLE IF NOT EXISTS CambiaEvent(
+CREATE TABLE IF NOT EXISTS cambiaevent(
 
     -- To uniquely identify each row.
     cambiaIncrement         INTEGER AUTO_INCREMENT  PRIMARY KEY,
@@ -211,7 +211,7 @@ CREATE TABLE IF NOT EXISTS CambiaEvent(
 
 
 
-CREATE TABLE IF NOT EXISTS CrossRefEvent
+CREATE TABLE IF NOT EXISTS crossrefevent
 (
 
     -- Auto increment for easy primary keys
@@ -256,7 +256,7 @@ CREATE TABLE IF NOT EXISTS CrossRefEvent
 
 
 
-CREATE TABLE IF NOT EXISTS DataCiteEvent(
+CREATE TABLE IF NOT EXISTS dataciteevent(
 
     --   Auto increment for easy primary keys.
     dataCiteIncrement       INTEGER AUTO_INCREMENT PRIMARY KEY,
@@ -296,7 +296,7 @@ CREATE TABLE IF NOT EXISTS DataCiteEvent(
 );
 
 
-CREATE TABLE IF NOT EXISTS F1000Event(
+CREATE TABLE IF NOT EXISTS f1000event(
 
     -- To uniquely identify each row.
     f1000Increment  		INTEGER AUTO_INCREMENT  PRIMARY KEY,
@@ -360,7 +360,7 @@ CREATE TABLE IF NOT EXISTS F1000Event(
 );
 
 
-CREATE TABLE IF NOT EXISTS HypothesisEvent(
+CREATE TABLE IF NOT EXISTS hypothesisevent(
 
     -- To uniquely identify each row.
     hypothesisIncrement     INTEGER AUTO_INCREMENT  PRIMARY KEY,
@@ -431,7 +431,7 @@ CREATE TABLE IF NOT EXISTS HypothesisEvent(
 
 
 
-CREATE TABLE IF NOT EXISTS NewsfeedEvent(
+CREATE TABLE IF NOT EXISTS newsfeedevent(
 
     -- To uniquely identify each row.
     newsfeedIncrement       INTEGER AUTO_INCREMENT  PRIMARY KEY,
@@ -506,7 +506,7 @@ CREATE TABLE IF NOT EXISTS NewsfeedEvent(
 
 
 
-CREATE TABLE IF NOT EXISTS RedditEvent(   
+CREATE TABLE IF NOT EXISTS redditevent(   
 
     --  Auto increment for easy primary keys.
     redditIncrement         INTEGER AUTO_INCREMENT PRIMARY KEY,
@@ -575,12 +575,12 @@ CREATE TABLE IF NOT EXISTS RedditEvent(
     subjectIssuedDate       datetime,
     
     --  Foreign key to reference the doi
-	FOREIGN KEY (objectID) REFERENCES Main(objectID) ON DELETE CASCADE
+	FOREIGN KEY (objectID) REFERENCES main(objectID) ON DELETE CASCADE
     );
 
 
 
-CREATE TABLE IF NOT EXISTS RedditLinksEvent(
+CREATE TABLE IF NOT EXISTS redditlinksevent(
 
     -- To uniquely identify each row.
     redditLinksIncrement    INTEGER AUTO_INCREMENT  PRIMARY KEY,
@@ -648,7 +648,7 @@ CREATE TABLE IF NOT EXISTS RedditLinksEvent(
 
 
 
-CREATE TABLE IF NOT EXISTS StackexchangeEvent(
+CREATE TABLE IF NOT EXISTS stackexchangeevent(
 
     --  Auto increment for easy primary keys.
     stackExchangeIncrement  INTEGER AUTO_INCREMENT PRIMARY KEY,
@@ -719,7 +719,7 @@ CREATE TABLE IF NOT EXISTS StackexchangeEvent(
 );
 
 
-CREATE TABLE IF NOT EXISTS TwitterEvent(
+CREATE TABLE IF NOT EXISTS twitterevent(
 
     -- Uniquely identify each row.
     twitterIncrement 		INTEGER AUTO_INCREMENT PRIMARY KEY,
@@ -803,7 +803,7 @@ CREATE TABLE IF NOT EXISTS TwitterEvent(
 
 
 
-CREATE TABLE IF NOT EXISTS WebEvent(
+CREATE TABLE IF NOT EXISTS webevent(
 
     -- To uniquely identify each row.
     webIncrement            INTEGER AUTO_INCREMENT  PRIMARY KEY,
@@ -868,7 +868,7 @@ CREATE TABLE IF NOT EXISTS WebEvent(
 
 
 
-    CREATE TABLE IF NOT EXISTS WikipediaEvent(
+    CREATE TABLE IF NOT EXISTS wikipediaevent(
     
     --  Auto increment for easy primary keys
     wikipediaIncrement      INTEGER AUTO_INCREMENT PRIMARY KEY,
@@ -939,7 +939,7 @@ CREATE TABLE IF NOT EXISTS WebEvent(
 
 
 
-    CREATE TABLE IF NOT EXISTS WordpressEvent(
+    CREATE TABLE IF NOT EXISTS wordpressevent(
 
     --  Auto increment for easy primary keys.
     wordPressIncrement      INTEGER AUTO_INCREMENT PRIMARY KEY,

--- a/SQL/paperbuzz_dump/paperbuzz.sql
+++ b/SQL/paperbuzz_dump/paperbuzz.sql
@@ -1,5 +1,5 @@
-CREATE DATABASE paperbuzzEventData;
-USE paperbuzzEventData;
+CREATE DATABASE paperbuzzeventdata;
+USE paperbuzzeventdata;
 
 CREATE TABLE `event_data_json` (
   `json` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin,

--- a/pythonScripts/Ingest/cambiaLens.py
+++ b/pythonScripts/Ingest/cambiaLens.py
@@ -83,7 +83,7 @@ def cambiaLensIngest(uniqueEvent, cursor, connection):
 
         # Fetch all records from the 4 columns in the main table from t_obj_id and is placed into a list of tuples.
         # (firstCambiaEvent, lastCambiaevent, totalEvents, totalCambiaEvents)
-        listOfDictQuery = "SELECT firstCambiaEvent, lastCambiaEvent, totalEvents, totalCambiaEvents FROM Main WHERE objectID = \'" + t_obj_id + "\';"
+        listOfDictQuery = "SELECT firstCambiaEvent, lastCambiaEvent, totalEvents, totalCambiaEvents FROM main WHERE objectID = \'" + t_obj_id + "\';"
         cursor.execute(listOfDictQuery)
         row = cursor.fetchone()
 
@@ -147,7 +147,7 @@ def cambiaLensIngest(uniqueEvent, cursor, connection):
 
     # These statements are used to insert data into Cambia Event's Table
     # SQL which inserts into event table
-    add_event = ("INSERT IGNORE INTO CambiaEvent " "(sourceID, objectID, subjectID, eventID, occurredAt, timeObserved, relationType, sourceToken, license, termsOfUse, updatedReason, updated, eventAction, workSubtypeID, workTypeID, subjectTitle, subjectPID, jurisdiction, updatedDate) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s);")
+    add_event = ("INSERT IGNORE INTO cambiaevent " "(sourceID, objectID, subjectID, eventID, occurredAt, timeObserved, relationType, sourceToken, license, termsOfUse, updatedReason, updated, eventAction, workSubtypeID, workTypeID, subjectTitle, subjectPID, jurisdiction, updatedDate) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s);")
 
     # Values to insert into Cambia Event Table
     data_event = (t_source_id, t_obj_id, t_subj_id, t_id, t_occurred_at, t_dateTime, t_relation_type_id, t_source_token, t_license, t_terms, t_updated_reason, t_updated, t_action,

--- a/pythonScripts/Ingest/crossref.py
+++ b/pythonScripts/Ingest/crossref.py
@@ -55,7 +55,7 @@ def crossrefIngest(uniqueEvent, cursor, connection):
 
         # Fetch all records from the 4 columns in the main table from t_obj_id and is placed into a list of tuples.
         # (firstCrossrefEvent, lastCrossrefevent, totalEvents, totalCrossrefEvents)
-        listOfDictQuery = "SELECT firstCrossrefEvent, lastCrossrefEvent, totalEvents, totalCrossrefEvents FROM Main WHERE objectID = \'" + t_obj_id + "\';"
+        listOfDictQuery = "SELECT firstCrossrefEvent, lastCrossrefEvent, totalEvents, totalCrossrefEvents FROM main WHERE objectID = \'" + t_obj_id + "\';"
         cursor.execute(listOfDictQuery)
         row = cursor.fetchone()
 

--- a/pythonScripts/Ingest/datacite.py
+++ b/pythonScripts/Ingest/datacite.py
@@ -51,7 +51,7 @@ def dataciteIngest(uniqueEvent, cursor, connection):
 
         # Fetch all records from the 4 columns in the main table from t_obj_id and is placed into a list of tuples.
         # (firstDataciteEvent, lastDataciteevent, totalEvents, totalDataciteEvents)
-        listOfDictQuery = "SELECT firstDataciteEvent, lastDataciteEvent, totalEvents, totalDataciteEvents FROM Main WHERE objectID = \'" + t_obj_id + "\';"
+        listOfDictQuery = "SELECT firstDataciteEvent, lastDataciteEvent, totalEvents, totalDataciteEvents FROM main WHERE objectID = \'" + t_obj_id + "\';"
         cursor.execute(listOfDictQuery)
         row = cursor.fetchone()
 
@@ -116,7 +116,7 @@ def dataciteIngest(uniqueEvent, cursor, connection):
     # These statements are used to insert data into Crossref Event's Table
     # SQL which inserts into event table
     # This was a previous layout of columns in the Datacite event table before we remodeled the database
-    add_event = ("INSERT IGNORE INTO DataCiteEvent " "(license, objectID, occurredAt, subjectID, eventID, termsOfUse, messageAction, sourceID, timeObserved, relationType) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s, %s)")
+    add_event = ("INSERT IGNORE INTO dataciteevent " "(license, objectID, occurredAt, subjectID, eventID, termsOfUse, messageAction, sourceID, timeObserved, relationType) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s, %s)")
 
     # Values to insert into Datacite event table
     data_event = (t_license, t_obj_id, t_occurred_at, t_subj_id, t_id, t_terms,

--- a/pythonScripts/Ingest/f1000.py
+++ b/pythonScripts/Ingest/f1000.py
@@ -82,7 +82,7 @@ def F1000Ingest(uniqueEvent, cursor, connection):
 
         # Fetch all records from the 4 columns in the main table from t_obj_id and is placed into a list of tuples.
         # (firstF1000Event, lastF1000event, totalEvents, totalF1000Events)
-        listOfDictQuery = "SELECT firstF1000Event, lastF1000Event, totalEvents, totalF1000Events FROM Main WHERE objectID = \'" + t_obj_id + "\';"
+        listOfDictQuery = "SELECT firstF1000Event, lastF1000Event, totalEvents, totalF1000Events FROM main WHERE objectID = \'" + t_obj_id + "\';"
         cursor.execute(listOfDictQuery)
         row = cursor.fetchone()
 
@@ -147,7 +147,7 @@ def F1000Ingest(uniqueEvent, cursor, connection):
     # These statements are used to insert data into F1000 Event's Table
     # SQL which inserts into event table
     # This was a previous layout of columns in the F1000 event table before we remodeled the database
-    add_event = ("INSERT IGNORE INTO F1000event " "(sourceID, objectID, subjectID, eventID, occurredAt, timeObserved, relationType, sourceToken, license, termsOfUse, evidenceRecord, eventAction, subjectPID, subjectURL, alternativeID, workTypeID, objectPID, objectURL)" "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
+    add_event = ("INSERT IGNORE INTO f1000event " "(sourceID, objectID, subjectID, eventID, occurredAt, timeObserved, relationType, sourceToken, license, termsOfUse, evidenceRecord, eventAction, subjectPID, subjectURL, alternativeID, workTypeID, objectPID, objectURL)" "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
 
     # Values to insert into F1000 event table
     data_event = (t_source_id, t_obj_id, t_subj_id, t_id, t_occurred_at, t_dateTime, t_relation_type_id, t_source_token, t_license,

--- a/pythonScripts/Ingest/hypothesis.py
+++ b/pythonScripts/Ingest/hypothesis.py
@@ -89,7 +89,7 @@ def hypothesisIngest(uniqueEvent, cursor, connection):
 
             # Fetch all records from the 4 columns in the main table from t_obj_id and is placed into a list of tuples.
             # (firstHypothesisEvent, lastHypothesisevent, totalEvents, totalHypothesisEvents)
-            listOfDictQuery = "SELECT firsthypothesisEvent, lasthypothesisEvent, totalEvents, totalHypothesisEvents FROM Main WHERE objectID = \'" + t_obj_id + "\';"
+            listOfDictQuery = "SELECT firsthypothesisEvent, lasthypothesisEvent, totalEvents, totalHypothesisEvents FROM main WHERE objectID = \'" + t_obj_id + "\';"
             cursor.execute(listOfDictQuery)
             row = cursor.fetchone()
 
@@ -156,7 +156,7 @@ def hypothesisIngest(uniqueEvent, cursor, connection):
     # These statements are used to insert data into Hypothesis Event's Table
     # SQL which inserts into event table
     # This was a previous layout of columns in the Hypothesis event table before we remodeled the database
-    add_event = ("INSERT IGNORE INTO hypothesisEvent " "(eventID, objectID, occurredAt, license, sourceToken, subjectID, evidenceRecord, termsOfUse, eventAction, subjectPID, subj_json_url, subjectURL, subjectType, subjectTitle, subjectIssued, sourceID, objectPID, objectURL, timeObserved, relationType ) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s, %s)")
+    add_event = ("INSERT IGNORE INTO hypothesisevent " "(eventID, objectID, occurredAt, license, sourceToken, subjectID, evidenceRecord, termsOfUse, eventAction, subjectPID, subj_json_url, subjectURL, subjectType, subjectTitle, subjectIssued, sourceID, objectPID, objectURL, timeObserved, relationType ) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s, %s)")
 
     # Values to insert into Hypothesis event table
     data_event = (t_id, t_obj_id, t_occurred_at, t_license, t_source_token, t_subj_id, t_evidence_record, t_terms, t_action,

--- a/pythonScripts/Ingest/ingestJSONMain.py
+++ b/pythonScripts/Ingest/ingestJSONMain.py
@@ -25,7 +25,7 @@ except:
     logging.info("Cannot determine how you intend to run the program")
 
 # Change these to suit your system
-dataDirectory = "../JSON"
+dataDirectory = "./JSON"
 print("MySQL Credentials")
 mysql_username = input("Username: ")
 mysql_password = input("Password: ")
@@ -40,7 +40,6 @@ def main():
         mysql_password), host='127.0.0.1', database='crossrefeventdatamain')
     cursor = connection.cursor()  # Allows us to have multiple seperate working environments through the same connection. Can create individual cursors for each (event) table? redditC = cnx.cursor()?
 
-    # dataDirectory = "/home/fg7626/crossrefDataDumps"
     for (path, dirnames, filenames) in os.walk(dataDirectory):
         files.extend(os.path.join(path, name) for name in sorted(filenames))
 

--- a/pythonScripts/Ingest/newsfeed.py
+++ b/pythonScripts/Ingest/newsfeed.py
@@ -89,7 +89,7 @@ def newsfeedIngest(uniqueEvent, cursor, connection):
 
         # Fetch all records from the 4 columns in the main table from t_obj_id and is placed into a list of tuples.
         # (firstNewsfeedEvent, lastNewsfeedevent, totalEvents, totalNewsfeedEvents)
-        listOfDictQuery = "SELECT firstNewsfeedEvent, lastNewsfeedEvent, totalEvents, totalNewsfeedEvents FROM Main WHERE objectID = \'" + t_obj_id + "\';"
+        listOfDictQuery = "SELECT firstNewsfeedEvent, lastNewsfeedEvent, totalEvents, totalNewsfeedEvents FROM main WHERE objectID = \'" + t_obj_id + "\';"
         cursor.execute(listOfDictQuery)
         row = cursor.fetchone()
 
@@ -154,7 +154,7 @@ def newsfeedIngest(uniqueEvent, cursor, connection):
     # These statements are used to insert data into Newsfeed Event's Table
     # SQL which inserts into event table
     # This was a previous layout of columns in the Newsfeed event table before we remodeled the database
-    add_event = ("INSERT IGNORE INTO NewsfeedEvent " "(eventID, objectID, occurredAt, license, termsOfUse, updatedReason, updated, sourceToken, subjectID, evidenceRecord, eventAction, subjectPID, subjectType, subjectTitle, subjectURL, sourceID, objectPID, objectURL, timeObserved, updatedDate, relationType) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
+    add_event = ("INSERT IGNORE INTO newsfeedevent " "(eventID, objectID, occurredAt, license, termsOfUse, updatedReason, updated, sourceToken, subjectID, evidenceRecord, eventAction, subjectPID, subjectType, subjectTitle, subjectURL, sourceID, objectPID, objectURL, timeObserved, updatedDate, relationType) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
 
     # Values to insert into Newsfeed event table
     data_event = (t_id, t_obj_id, t_occurred_at, t_license, t_terms, t_updated_reason, t_updated, t_source_token, t_subj_id, t_evidence_record,

--- a/pythonScripts/Ingest/reddit.py
+++ b/pythonScripts/Ingest/reddit.py
@@ -89,7 +89,7 @@ def redditIngest(uniqueEvent, cursor, connection):
 
         # Fetch all records from the 4 columns in the main table from t_obj_id and is placed into a list of tuples.
         # (firstRedditEvent, lastRedditevent, totalEvents, totalRedditEvents)
-        listOfDictQuery = "SELECT firstRedditEvent, lastRedditEvent, totalEvents, totalRedditEvents FROM Main WHERE objectID = \'" + t_obj_id + "\';"
+        listOfDictQuery = "SELECT firstRedditEvent, lastRedditEvent, totalEvents, totalRedditEvents FROM main WHERE objectID = \'" + t_obj_id + "\';"
         cursor.execute(listOfDictQuery)
         row = cursor.fetchone()
 

--- a/pythonScripts/Ingest/redditLinks.py
+++ b/pythonScripts/Ingest/redditLinks.py
@@ -83,7 +83,7 @@ def redditLinksIngest(uniqueEvent, cursor, connection):
 
         # Fetch all records from the 4 columns in the main table from t_obj_id and is placed into a list of tuples.
         # (firstRedditLinksEvent, lastRedditLinksevent, totalEvents, totalRedditLinksEvents)
-        listOfDictQuery = "SELECT firstRedditLinksEvent, lastRedditLinksEvent, totalEvents, totalRedditLinksEvents FROM Main WHERE objectID = \'" + t_obj_id + "\';"
+        listOfDictQuery = "SELECT firstRedditLinksEvent, lastRedditLinksEvent, totalEvents, totalRedditLinksEvents FROM main WHERE objectID = \'" + t_obj_id + "\';"
         cursor.execute(listOfDictQuery)
         row = cursor.fetchone()
 
@@ -148,7 +148,7 @@ def redditLinksIngest(uniqueEvent, cursor, connection):
     # These statements are used to insert data into RedditLinks Event's Table
     # SQL which inserts into event table
     # This was a previous layout of columns in the RedditLinks event table before we remodeled the database
-    add_event = ("INSERT IGNORE INTO RedditLinksevent " "(eventID, objectID, occurredAt, license, termsOfUse, updatedReason, updated, sourceToken, subjectID, evidenceRecord, eventAction, subjectPID, subjectURL, sourceID, objectPID, objectURL, timeObserved, updatedDate, relationType) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
+    add_event = ("INSERT IGNORE INTO redditlinksevent " "(eventID, objectID, occurredAt, license, termsOfUse, updatedReason, updated, sourceToken, subjectID, evidenceRecord, eventAction, subjectPID, subjectURL, sourceID, objectPID, objectURL, timeObserved, updatedDate, relationType) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
 
     # Values to insert into redditLinks event table
     data_event = (t_id, t_obj_id, t_occurred_at, t_license, t_terms, t_updated_reason, t_updated, t_source_token, t_subj_id, t_evidence_record,

--- a/pythonScripts/Ingest/stackExchange.py
+++ b/pythonScripts/Ingest/stackExchange.py
@@ -90,7 +90,7 @@ def stackExchangeIngest(uniqueEvent, cursor, connection):
 
         # Fetch all records from the 4 columns in the main table from t_obj_id and is placed into a list of tuples.
         # (firststackExchangeEvent, laststackExchangeevent, totalEvents, totalstackExchangeEvents)
-        listOfDictQuery = "SELECT firststackExchangeEvent, laststackExchangeEvent, totalEvents, totalstackExchangeEvents FROM Main WHERE objectID = \'" + t_obj_id + "\';"
+        listOfDictQuery = "SELECT firststackExchangeEvent, laststackExchangeEvent, totalEvents, totalstackExchangeEvents FROM main WHERE objectID = \'" + t_obj_id + "\';"
         cursor.execute(listOfDictQuery)
         row = cursor.fetchone()
 
@@ -155,7 +155,7 @@ def stackExchangeIngest(uniqueEvent, cursor, connection):
     # These statements are used to insert data into stackExchange Event's Table
     # SQL which inserts into event table
     # This was a previous layout of columns in the stackExchange event table before we remodeled the database
-    add_event = ("INSERT IGNORE INTO stackExchangeevent " "(license, termsOfUse, objectID, sourceToken, occurredAt, subjectID, eventID, evidenceRecord,  subjectPID, subjectTitle, subjectIssuedDate, subjectType, subjectAuthorURL, subjectAuthorName, subjectAuthorID, sourceID, objectPID, objectURL, timeObserved, relationType) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
+    add_event = ("INSERT IGNORE INTO stackexchangeevent " "(license, termsOfUse, objectID, sourceToken, occurredAt, subjectID, eventID, evidenceRecord,  subjectPID, subjectTitle, subjectIssuedDate, subjectType, subjectAuthorURL, subjectAuthorName, subjectAuthorID, sourceID, objectPID, objectURL, timeObserved, relationType) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
 
     # Values to insert into stackExchange event table
     data_event = (t_license, t_terms, t_obj_id, t_source_token, t_occurred_at, t_subj_id, t_id, t_evidence_record, t_subj_pid,

--- a/pythonScripts/Ingest/twitter.py
+++ b/pythonScripts/Ingest/twitter.py
@@ -104,7 +104,7 @@ def twitterIngest(uniqueEvent, cursor, connection):
 
         # Fetch all records from the 4 columns in the main table from t_obj_id and is placed into a list of tuples.
         # (firstTwitterEvent, lastTwitterevent, totalEvents, totalTwitterEvents)
-        listOfDictQuery = "SELECT firstTwitterEvent, lastTwitterEvent, totalEvents, totalTwitterEvents FROM Main WHERE objectID = \'" + t_obj_id + "\';"
+        listOfDictQuery = "SELECT firstTwitterEvent, lastTwitterEvent, totalEvents, totalTwitterEvents FROM main WHERE objectID = \'" + t_obj_id + "\';"
         cursor.execute(listOfDictQuery)
         row = cursor.fetchone()
 
@@ -169,7 +169,7 @@ def twitterIngest(uniqueEvent, cursor, connection):
     # These statements are used to insert data into Twitter Event's Table
     # SQL which inserts into event table
     # This was a previous layout of columns in the Twitter event table before we remodeled the database
-    add_event = ("INSERT IGNORE INTO TwitterEvent " "(eventID, objectID, tweetAuthor, originalTweetAuthor, occurredAt, license, termsOfUse, updatedReason, updated, sourceToken, evidenceRecord, eventAction, subjectID, subjectPID, originalTweetURL, alternativeID, title, issued, sourceID, objectPID, objectURL, timeObserved, updatedDate, relationType)" "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
+    add_event = ("INSERT IGNORE INTO twitterevent " "(eventID, objectID, tweetAuthor, originalTweetAuthor, occurredAt, license, termsOfUse, updatedReason, updated, sourceToken, evidenceRecord, eventAction, subjectID, subjectPID, originalTweetURL, alternativeID, title, issued, sourceID, objectPID, objectURL, timeObserved, updatedDate, relationType)" "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
 
     # Values to insert into Twitter event table
     data_event = (t_id, t_obj_id, t_author_url, t_original_tweet_author, t_occurred_at, t_license, t_terms, t_updated_reason, t_updated, t_source_token, t_evidence_record, t_action, t_subj_id,

--- a/pythonScripts/Ingest/web.py
+++ b/pythonScripts/Ingest/web.py
@@ -78,7 +78,7 @@ def webIngest(uniqueEvent, cursor, connection):
 
         # Fetch all records from the 4 columns in the main table from t_obj_id and is placed into a list of tuples.
         # (firstWebEvent, lastWebevent, totalEvents, totalWebEvents)
-        listOfDictQuery = "SELECT firstWebEvent, lastWebEvent, totalEvents, totalWebEvents FROM Main WHERE objectID = \'" + t_obj_id + "\';"
+        listOfDictQuery = "SELECT firstWebEvent, lastWebEvent, totalEvents, totalWebEvents FROM main WHERE objectID = \'" + t_obj_id + "\';"
         cursor.execute(listOfDictQuery)
         row = cursor.fetchone()
 
@@ -143,7 +143,7 @@ def webIngest(uniqueEvent, cursor, connection):
     # These statements are used to insert data into Web Event's Table
     # SQL which inserts into event table
     # This was a previous layout of columns in the Web event table before we remodeled the database
-    add_event = ("INSERT IGNORE INTO webEvent " "(eventID, objectID, occurredAt, termsOfUse, updatedReason, updated, sourceToken, subjectID, evidenceRecord, eventAction, subjectPID, subjectURL, sourceID, objectPID, objectURL, timeObserved, updatedDate, relationType) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
+    add_event = ("INSERT IGNORE INTO webevent " "(eventID, objectID, occurredAt, termsOfUse, updatedReason, updated, sourceToken, subjectID, evidenceRecord, eventAction, subjectPID, subjectURL, sourceID, objectPID, objectURL, timeObserved, updatedDate, relationType) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
 
     # Values to insert into Web event table
     data_event = (t_id, t_obj_id, t_occurred_at, t_terms, t_updated_reason, t_updated, t_source_token, t_subj_id, t_evidence_record,

--- a/pythonScripts/Ingest/wikipedia.py
+++ b/pythonScripts/Ingest/wikipedia.py
@@ -87,7 +87,7 @@ def wikipediaIngest(uniqueEvent, cursor, connection):
 
         # Fetch all records from the 4 columns in the main table from t_obj_id and is placed into a list of tuples.
         # (firstWikipediaEvent, lastWikipediaevent, totalEvents, totalWikipediaEvents)
-        listOfDictQuery = "SELECT firstWikipediaEvent, lastWikipediaEvent, totalEvents, totalWikipediaEvents FROM Main WHERE objectID = \'" + t_obj_id + "\';"
+        listOfDictQuery = "SELECT firstWikipediaEvent, lastWikipediaEvent, totalEvents, totalWikipediaEvents FROM main WHERE objectID = \'" + t_obj_id + "\';"
         cursor.execute(listOfDictQuery)
         row = cursor.fetchone()
 
@@ -152,7 +152,7 @@ def wikipediaIngest(uniqueEvent, cursor, connection):
     # SQL which inserts into event table
     # This was a previous layout of columns in the Wikipedia event table before we remodeled the database
     add_event = (
-        "INSERT IGNORE INTO WikipediaEvent " "(license, termsOfUse, updatedDate, updatedReason, objectID, sourceToken, occurredAt, subjectID, eventID, evidenceRecord, eventAction, subjectPID, subjectTitle, subjectURL, subjectAPIURL, sourceID, objectPID, objectURL, timeObserved, relationType) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
+        "INSERT IGNORE INTO wikipediaevent " "(license, termsOfUse, updatedDate, updatedReason, objectID, sourceToken, occurredAt, subjectID, eventID, evidenceRecord, eventAction, subjectPID, subjectTitle, subjectURL, subjectAPIURL, sourceID, objectPID, objectURL, timeObserved, relationType) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
     # Values to insert into wikipediaevent table  - LEAVE OUT THE OBJECT ID
     data_event = (t_license, t_terms, t_updated_date, t_updated_reason, t_obj_id, t_source_token, t_occurred_at, t_subj_id, t_id, t_evidence_record,
                   t_action, t_subj_pid, t_subj_title, t_subj_url, t_api_url, t_source_id, t_obj_pid, t_obj_url, t_dateTime, t_relation_type_id)

--- a/pythonScripts/Ingest/wordpress.py
+++ b/pythonScripts/Ingest/wordpress.py
@@ -80,7 +80,7 @@ def wordpressIngest(uniqueEvent, cursor, connection):
 
             # Fetch all records from the 4 columns in the main table from t_obj_id and is placed into a list of tuples.
             # (firstWordpressEvent, lastWordpressevent, totalEvents, totalWordpressEvents)
-            listOfDictQuery = "SELECT firstWordpressEvent, lastWordpressEvent, totalEvents, totalWordpressEvents FROM Main WHERE objectID = \'" + t_obj_id + "\';"
+            listOfDictQuery = "SELECT firstWordpressEvent, lastWordpressEvent, totalEvents, totalWordpressEvents FROM main WHERE objectID = \'" + t_obj_id + "\';"
             cursor.execute(listOfDictQuery)
             row = cursor.fetchone()
 
@@ -144,7 +144,7 @@ def wordpressIngest(uniqueEvent, cursor, connection):
 
         # SQL which inserts into dataciteevent table
         # This was a previous layout of columns in the Wordpress event table before we remodeled the database
-        add_event = ("INSERT IGNORE INTO WordPressEvent " "(license, termsOfUse, objectID, sourceToken, occurredAt, subjectID, eventID, evidenceRecord, eventAction, subjectPID, subjectTitle, subjectType, sourceID, objectPID, objectURL, timeObserved, relationType) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
+        add_event = ("INSERT IGNORE INTO wordpressevent " "(license, termsOfUse, objectID, sourceToken, occurredAt, subjectID, eventID, evidenceRecord, eventAction, subjectPID, subjectTitle, subjectType, sourceID, objectPID, objectURL, timeObserved, relationType) " "VALUES(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
 
         # Values to insert into wordpressevent tabls
         data_event = (t_license, t_terms, t_obj_id, t_source_token, t_occurred_at, t_subj_id, t_id, t_evidence_record, t_action,

--- a/web/app.py
+++ b/web/app.py
@@ -15,7 +15,6 @@ from landingPageJournals import landingPageJournals
 from getPassword import getPassword
 
 # get the users password from crossrefeventdata/web/passwd.txt
-
 mysql_username = 'root'
 mysql_password = getPassword()
 
@@ -36,6 +35,7 @@ app2 = flask.Flask(__name__)
 # Database connection settings
 app2.config['MYSQL_USER'] = mysql_username
 app2.config['MYSQL_PASSWORD'] = mysql_password
+
 # Or use the database.table which will allow us to join the databases - the one with author, and the one with events
 app2.config['MYSQL_DB'] = 'crossrefeventdatamain'
 app2.config['MYSQL_CURSORCLASS'] = 'DictCursor'

--- a/web/landingPageArticles.py
+++ b/web/landingPageArticles.py
@@ -17,9 +17,6 @@ def landingPageArticles(mysql):
     
     #fetch result
     totalSumArticles = cursor.fetchone()
-    
-    #print result in terminal for testing purposes
-    print(totalSumArticles)
 
     #close cursor
     cursor.close()

--- a/web/landingPageJournals.py
+++ b/web/landingPageJournals.py
@@ -18,9 +18,6 @@ def landingPageJournals(mysql):
     #fetch result
     totalSumJournals = cursor.fetchone()
 
-    #print result in terminal for testing purposes
-    print(totalSumJournals)
-
     #close cursor
     cursor.close()
     

--- a/web/landingPageStats.py
+++ b/web/landingPageStats.py
@@ -18,9 +18,6 @@ def landingPageStats(mysql):
     #fetch result 
     totalSum = cursor.fetchone()
 
-    #print in terminal for testing purposes
-    print(totalSum)
-
     #close cursor
     cursor.close()
 

--- a/web/static/js/chartScript.js
+++ b/web/static/js/chartScript.js
@@ -289,7 +289,7 @@ var chart = c3.generate({
 	axis: {
 		x: {
 			label: {
-				text: 'Years',
+				text: '',
 				position: 'outer-center'
 			},
 			type: 'category',

--- a/web/templates/articleDashboard.html
+++ b/web/templates/articleDashboard.html
@@ -199,11 +199,18 @@
         <div class="col-sm-7" id="changeAfterChart">
             <h3 style="text-align: center;">Events for this article over {{years_list[0]}} - {{years_list[-1]}} </h3>
             <div id="chart"></div>
-
+            <div id="yearFilter" style="text-align: center;">
+                <form method="post" action="{{ url_for('articleDashboard') }}?DOI={{ article_detail.objectID }}" class="form-inline" name="YearRange">
+                    <label for="yearBox">Select a year (YYYY):</label>
+                    <input type="text" name="year" id="yearBox" size="4" maxlength="4" pattern="\d{4}">
+                    <input width="40%" type="submit" value="Update" class="form-control">
+                </form>
+            </div>
         </div>
     </div> <!-- end of row -->
     <div class="row">
         <div class="col-md-6"></div>
+        <!--
         <div class="col-md-6" id="yearFilter">
 
             <form method="post" action="{{ url_for('articleDashboard') }}?DOI={{ article_detail.objectID }}" class="form-inline" name="YearRange">
@@ -213,6 +220,7 @@
             </form>
 
         </div>
+        -->
     </div>
 
     <div class="row">


### PR DESCRIPTION
Mostly changing the case of table names since Ubuntu is case sensitive and we were not careful enough with the casing.
This was not an issue on Windows - I think because either Windows or the Windows variant of MySQL is not case sensitive.